### PR TITLE
Update why-tcphol.md

### DIFF
--- a/en/why-tcphol.md
+++ b/en/why-tcphol.md
@@ -25,11 +25,11 @@ connection. A red stream and a green stream:
 
 It becomes a TCP-based head of line block!
 
-As the packet loss rate increases, HTTP/2 performs less and less good. At 2%
-packet loss (which is a terrible network quality, mind you), tests have proven
-that HTTP/1 users are usually better off - because they typically have six TCP
-connections up to distribute the lost packet over so for each lost packet the
-other connections without loss can still continue.
+As the packet loss rate increases, the performance of HTTP/2 gets worse and 
+worse. At 2% packet loss (which is a terrible network quality, mind you), tests
+have proven that HTTP/1 users are usually better off - because they typically 
+have six TCP connections to distribute the lost packet over so for each lost 
+packet the other connections without loss can still continue.
 
 Fixing this issue is not easy, if at all possible, to do with TCP.
 


### PR DESCRIPTION
Minor language suggestions - "less and less good" is incorrect grammar I think; we could say "less and less well" or "more and more poorly", but both I think are more awkward than simply saying the "performance gets worse". or for emphasis "the performance gets worse and worse".

I also removed the word "up" later in the paragraph which didn't seem to be quite correct. I actually wanted to change this sentence to:

> "...they typically have six TCP connections over which the lost packet may be distributed, so for each lost packet the other connections without loss can still continue."

but I wasn't sure if had understood the meaning of that sentence correctly.